### PR TITLE
Fix Android manual install typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@ dependencies {
 On top, where imports are:
 
 ```java
-import com.ninty.react.ReactSystemSetting;
+import com.ninty.system.setting.SystemSettingPackage;
 ```
 
-Add the `ReactSystemSettingPackage` class to your list of exported packages.
+Add the `SystemSettingPackage` class to your list of exported packages.
 
 ```java
 @Override
 protected List<ReactPackage> getPackages() {
     return Arrays.asList(
             new MainReactPackage(),
-            new ReactSystemSettingPackage()
+            new SystemSettingPackage()
     );
 }
 ```


### PR DESCRIPTION
Some info on the android manual installing guide are wrong (import and package name).