### PR TITLE
Opt in Android permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ protected List<ReactPackage> getPackages() {
 ```
 
 **app/AndroidManifest.xml**
+Add permissions you want to use
 ```xml
 <!-- change brightness & airplane -->
 <uses-permission android:name="android.permission.WRITE_SETTINGS" />

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ protected List<ReactPackage> getPackages() {
 }
 ```
 
+**app/AndroidManifest.xml**
+```xml
+<!-- change brightness & airplane -->
+<uses-permission android:name="android.permission.WRITE_SETTINGS" />
+
+<!-- get wifi state-->
+<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+
+<!-- get bluetooth state -->
+<uses-permission android:name="android.permission.BLUETOOTH"/>
+```
+
 
 ## Usage
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,13 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ninty.system.setting">
 
-    <!-- change brightness & airplane -->
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-
-    <!-- get wifi state-->
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-
-    <!-- get bluetooth state -->
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
-
 </manifest>


### PR DESCRIPTION
Current:
- delete the permission in the AndroidManifest in the node_modules

If you clone the repo again and yarn permissions will be reset.

PR
No default permissions, add in README to add permissions in app AndroidManifest.xml