### PR TITLE
change grade.syntax to conform to new specification

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,5 +15,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }


### PR DESCRIPTION
This uses the new implementation syntax instead of compile which errors now with:

```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```