### PR TITLE
add ability to open app system settings

### DIFF
--- a/SystemSetting.js
+++ b/SystemSetting.js
@@ -1,4 +1,4 @@
-import { NativeModules, NativeEventEmitter } from 'react-native'
+import { NativeModules, NativeEventEmitter, Linking, Platform } from 'react-native'
 
 import Utils from './Utils'
 
@@ -186,6 +186,23 @@ export default class SystemSetting {
     static switchAirplane(complete) {
         SystemSetting.listenEvent(complete)
         SystemSettingNative.switchAirplane()
+    }
+
+    static async openAppSystemSettings() {
+        switch(Platform.OS) {
+            case 'ios': {
+                const settingsLink = 'app-settings:';
+                const supported = await Linking.canOpenURL(settingsLink)
+                if (supported) await Linking.openURL(settingsLink);
+                break;
+            }
+            case 'android': 
+                await SystemSettingNative.openAppSystemSettings()
+                break;
+            default:
+                throw new Error('unknown platform')
+                break;    
+        }
     }
 
     static async addBluetoothListener(callback) {

--- a/android/src/main/java/com/ninty/system/setting/SystemSetting.java
+++ b/android/src/main/java/com/ninty/system/setting/SystemSetting.java
@@ -473,6 +473,17 @@ public class SystemSetting extends ReactContextBaseJavaModule implements Activit
         }
     }
 
+    @ReactMethod
+    public void openAppSystemSettings() {
+        Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+        intent.setData(Uri.parse("package:" + mContext.getPackageName()));
+        if (intent.resolveActivity(mContext.getPackageManager()) != null) {
+            mContext.startActivity(intent);
+        }
+    }
+
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         SysSettings setting = SysSettings.get(requestCode);


### PR DESCRIPTION
It would be useful to add the ability to open the os system settings for the current app (for example to ask people to give push permissions, if they already rejected them). This code is adapted from https://github.com/levelasquez/react-native-android-open-settings