### PR TITLE
Detect wether software navbar is visible

### DIFF
--- a/SystemSetting.js
+++ b/SystemSetting.js
@@ -1,4 +1,4 @@
-import { NativeModules, NativeEventEmitter } from 'react-native'
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native'
 
 import Utils from './Utils'
 
@@ -186,6 +186,15 @@ export default class SystemSetting {
     static switchAirplane(complete) {
         SystemSetting.listenEvent(complete)
         SystemSettingNative.switchAirplane()
+    }
+
+    static async androidAreSoftKeysVisible() {
+        switch(Platform.OS) {
+            case 'android': 
+                return await SystemSettingNative.softKeysVisible()
+            default:
+                throw new Error('only available on android')
+        }
     }
 
     static async addBluetoothListener(callback) {

--- a/android/src/main/java/com/ninty/system/setting/SystemSetting.java
+++ b/android/src/main/java/com/ninty/system/setting/SystemSetting.java
@@ -15,6 +15,8 @@ import android.os.Build;
 import android.provider.Settings;
 import android.util.Log;
 import android.view.WindowManager;
+import android.util.DisplayMetrics;
+import android.view.Display;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -473,6 +475,26 @@ public class SystemSetting extends ReactContextBaseJavaModule implements Activit
         }
     }
 
+    @ReactMethod
+    public void softKeysVisible(Promise promise) {    
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+            promise.resolve(false);
+        }
+        Display display = ((WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+
+        DisplayMetrics realDisplayMetrics = new DisplayMetrics();
+        display.getRealMetrics(realDisplayMetrics);
+        int realHeight = realDisplayMetrics.heightPixels;
+        int realWidth = realDisplayMetrics.widthPixels;
+
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        display.getMetrics(displayMetrics);
+        int displayHeight = displayMetrics.heightPixels;
+        int displayWidth = displayMetrics.widthPixels;
+
+        promise.resolve((realWidth > displayWidth) || (realHeight > displayHeight));
+    }
+    
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         SysSettings setting = SysSettings.get(requestCode);


### PR DESCRIPTION
This provides functionality to detect whether the nav bar is visible on android. This comes in handy, when drawing under a transparent navbar, to figure out wether padding needs to be added. But older devices sometimes have physical buttons and on Samsung devices the nav bar is often not shown. In those cases this will detect that no soft key nabber is visible.

Code adapted from
https://github.com/lequanghuylc/react-native-detect-navbar-android