### PR TITLE
Fixing setBrightness "expected the main thread" exception

### DIFF
--- a/ios/RTCSystemSetting.m
+++ b/ios/RTCSystemSetting.m
@@ -85,8 +85,10 @@
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(setBrightness:(float)val resolve:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
-    [[UIScreen mainScreen] setBrightness:val];
-    resolve([NSNumber numberWithBool:YES]);
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [[UIScreen mainScreen] setBrightness:val];
+        resolve([NSNumber numberWithBool:YES]);
+    });
 }
 
 RCT_EXPORT_METHOD(getBrightness:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){


### PR DESCRIPTION
We are getting this exception on iOS 13:

> Exception 'threading violation: expected the main thread' was thrown while invoking setBrightness on target SystemSetting with params

Wrapping `setBrightness` call with `dispatch_get_main_queue` fixed the crash for us. This also fixes #88.