### PR TITLE
grantWriteSettingPremission -> grantWriteSettingPermission

### DIFF
--- a/API.md
+++ b/API.md
@@ -24,7 +24,7 @@ setBrightness(val:float) => Promise | Set the system brightness by specified val
 getAppBrightness() => Promise | Get the app brightness, and it will returns system brightness if you haven't call `setAppBrightness(val)` yet. (iOS allways returns system brightness)
 getScreenMode() => Promise| (Only for Android, iOS will return -1). Get the screen mode, 0 is manual, while 1 is automatic.
 \* setScreenMode(mode:int) => Promise|(Only for Android, iOS cannot change it). Change the screen mode, 0 is manual, while 1 is automatic.<br><br>Return false if permission deny ( iOS always be true
-grantWriteSettingPremission()| open app setting page. It's user-friendly when you need some permission. Normally, you can call it if `setScreenMode()`, `setBrightness()` or `setBrightnessForce()` return false 
+grantWriteSettingPermission()| open app setting page. It's user-friendly when you need some permission. Normally, you can call it if `setScreenMode()`, `setBrightness()` or `setBrightnessForce()` return false 
 \* saveBrightness()|It will save current brightness and screen mode.
 restoreBrightness() => Promise|Restore brightness and screen mode back to saveBrightness(). While iOS only restore the brightness, Android will restore both. <br><br>You should call this before setBrightness() or setBrightnessForce(). <br><br>It will return the saved brightness.
 ---|---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ new API: `switchBluetoothSilence()`, see [detail](https://github.com/c19354837/r
 
 fix bug - `setVolume(val, config)` will cause a crash when `type` is null, see [detail](https://github.com/c19354837/react-native-system-setting/issues/22)
 
-fix bug - `grantWriteSettingPremission()` navigates to the wrong page, see [detail](https://github.com/c19354837/react-native-system-setting/issues/24)
+fix bug - `grantWriteSettingPermission()` navigates to the wrong page, see [detail](https://github.com/c19354837/react-native-system-setting/issues/24)
 
 # V1.2.4
 **2018-03-14**

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ SystemSetting.getBrightness().then((brightness)=>{
 SystemSetting.setBrightnessForce(0.5).then((success)=>{
     !success && Alert.alert('Permission Deny', 'You have no permission changing settings',[
 	   {'text': 'Ok', style: 'cancel'},
-	   {'text': 'Open Setting', onPress:()=>SystemSetting.grantWriteSettingPremission()}
+	   {'text': 'Open Setting', onPress:()=>SystemSetting.grantWriteSettingPermission()}
 	])
 });
 
@@ -280,7 +280,7 @@ Default permissions are removed since V1.5.0, see [this PR](https://github.com/c
 
 ### Runtime permission for Android 6+
 
-Change *brightness* and *screen mode* need `android.permission.WRITE_SETTINGS` which user can disable it in phone Setting. When you call `setScreenMode()`, `setBrightness()` or `setBrightnessForce()` , it will return false if the app has no permission, and you can call `SystemSetting.grantWriteSettingPremission()` to guide user to app setting page. see [example](https://github.com/c19354837/react-native-system-setting/tree/master/examples/SystemSettingExample)
+Change *brightness* and *screen mode* need `android.permission.WRITE_SETTINGS` which user can disable it in phone Setting. When you call `setScreenMode()`, `setBrightness()` or `setBrightnessForce()` , it will return false if the app has no permission, and you can call `SystemSetting.grantWriteSettingPermission()` to guide user to app setting page. see [example](https://github.com/c19354837/react-native-system-setting/tree/master/examples/SystemSettingExample)
 
 > If you just want to change app's brightness, you can call `setAppBrightness(val)`, and it doesn't require any permission. see [API](https://github.com/c19354837/react-native-system-setting/blob/master/API.md)
 

--- a/SystemSetting.js
+++ b/SystemSetting.js
@@ -61,7 +61,7 @@ export default class SystemSetting {
         }
     }
 
-    static grantWriteSettingPremission() {
+    static grantWriteSettingPermission() {
         if (Utils.isAndroid) {
             SystemSettingNative.openWriteSetting()
         }

--- a/android/src/main/java/com/ninty/system/setting/SystemSetting.java
+++ b/android/src/main/java/com/ninty/system/setting/SystemSetting.java
@@ -336,7 +336,7 @@ public class SystemSetting extends ReactContextBaseJavaModule implements Activit
             }
         }
         if (reject) {
-            promise.reject("-1", "write_settings premission is blocked by system");
+            promise.reject("-1", "write_settings permission is blocked by system");
         } else {
             promise.resolve(true);
         }

--- a/examples/SystemSettingExample/App.js
+++ b/examples/SystemSettingExample/App.js
@@ -112,7 +112,7 @@ export default class SystemSettingExample extends Component {
         if (!result) {
             Alert.alert('Permission Deny', 'You have no permission changing settings', [
                 { 'text': 'Ok', style: 'cancel' },
-                { 'text': 'Open Setting', onPress: () => SystemSetting.grantWriteSettingPremission() }
+                { 'text': 'Open Setting', onPress: () => SystemSetting.grantWriteSettingPermission() }
             ])
             return
         }


### PR DESCRIPTION
Changed `grantWriteSettingPremission` to `grantWriteSettingPermission` per [Issue #97 ](https://github.com/c19354837/react-native-system-setting/issues/97)