### PR TITLE
Add TypeScript definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# V1.7.5
+**2020-09-02**
+
+adds TypeScript definitions, see [detail](https://github.com/c19354837/react-native-system-setting/pull/116)
+
 # V1.7.4
 **2020-01-30**
 

--- a/SystemSetting.d.ts
+++ b/SystemSetting.d.ts
@@ -1,0 +1,79 @@
+export {};
+
+interface EmitterSubscription {
+  remove: () => void;
+}
+
+type VolumeType =
+  | "call"
+  | "system"
+  | "ring"
+  | "music"
+  | "alarm"
+  | "notification";
+
+interface VolumeConfig {
+  type?: VolumeType;
+  playSound?: boolean;
+  showUI?: boolean;
+}
+
+interface VolumeData {
+  value: number;
+  call?: number;
+  system?: number;
+  ring?: number;
+  music?: number;
+  alarm?: number;
+  notification?: number;
+}
+
+interface SystemSetting {
+  getBrightness: () => Promise<number>;
+  setBrightness: (val: number) => Promise<boolean>;
+  setBrightnessForce: (val: number) => Promise<boolean>;
+  getAppBrightness: () => Promise<number>;
+  setAppBrightness: (val: number) => Promise<true>;
+  grantWriteSettingPremission: () => void;
+  getScreenMode: () => Promise<number>;
+  setScreenMode: (val: number) => Promise<boolean>;
+  saveBrightness: () => Promise<void>;
+  restoreBrightness: () => number;
+  getVolume: (type?: VolumeType) => Promise<number>;
+  setVolume: (value: number, config?: VolumeConfig | VolumeType) => void;
+  addVolumeListener: (
+    callback: (volumeData: VolumeData) => void
+  ) => EmitterSubscription;
+  removeVolumeListener: (listener?: EmitterSubscription) => void;
+  isWifiEnabled: () => Promise<boolean>;
+  switchWifiSilence: () => void;
+  switchWifi: () => void;
+  isLocationEnabled: () => Promise<boolean>;
+  getLocationMode: () => Promise<number>;
+  switchLocation: () => void;
+  isBluetoothEnabled: () => Promise<boolean>;
+  switchBluetooth: () => void;
+  switchBluetoothSilence: () => void;
+  isAirplaneEnabled: () => Promise<boolean>;
+  switchAirplane: () => void;
+  openAppSystemSettings: () => Promise<void>;
+  addBluetoothListener: (
+    callback: (bluetoothEnabled: boolean) => void
+  ) => Promise<EmitterSubscription>;
+  addWifiListener: (
+    callback: (wifiEnabled: boolean) => void
+  ) => Promise<EmitterSubscription | null>;
+  addLocationListener: (
+    callback: (locationEnabled: boolean) => void
+  ) => Promise<EmitterSubscription | null>;
+  addLocationModeListener: (
+    callback: (locationMode: number) => void
+  ) => Promise<EmitterSubscription | null>;
+  addAirplaneListener: (
+    callback: (airplaneModeEnabled: boolean) => void
+  ) => Promise<EmitterSubscription | null>;
+  removeListener: (listener?: EmitterSubscription) => void;
+}
+
+declare const systemSetting: SystemSetting;
+export default systemSetting;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-system-setting",
-    "version": "1.7.4",
+    "version": "1.7.5",
     "description": "provide some system setting APIs. Volume, brightness, wifi, location, bluetooth, airplane...",
     "main": "SystemSetting.js",
     "types": "SystemSetting.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.7.4",
     "description": "provide some system setting APIs. Volume, brightness, wifi, location, bluetooth, airplane...",
     "main": "SystemSetting.js",
+    "types": "SystemSetting.d.ts",
     "homepage": "https://github.com/c19354837/react-native-system-setting",
     "bugs": {
         "url": "https://github.com/c19354837/react-native-system-setting/issues"


### PR DESCRIPTION
Been using these types for a while - saw issue #111 and wanted to chip in!

I was tempted to add `enum`s for things like the volume types, "screenMode" int, "locationMode" int, etc, but since the library does not export those, I figured a no-JS-change PR would be appropriate first.