### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RCTSystemSetting.podspec
+++ b/RCTSystemSetting.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files    = 'ios/*.{h,m}'
   s.preserve_paths  = "**/*.js"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Xcode 12 fails to build if a module depends on React instead of React-Core.
 Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116