### PR TITLE
fix: switchlocation mehtod shows warning while adding callback with it.

### DIFF
--- a/SystemSetting.d.ts
+++ b/SystemSetting.d.ts
@@ -50,7 +50,7 @@ interface SystemSetting {
   switchWifi: () => void;
   isLocationEnabled: () => Promise<boolean>;
   getLocationMode: () => Promise<number>;
-  switchLocation: () => void;
+  switchLocation: (callback: () => void) => void;
   isBluetoothEnabled: () => Promise<boolean>;
   switchBluetooth: () => void;
   switchBluetoothSilence: () => void;


### PR DESCRIPTION
For `switchLocation` method typescript validation is incompatible with actual implementation. `switchLocation` method requires a callback function inside it that is not defined inside `SystemSetting.d.ts`. If that callback not added app crashes with `complete function is undefined`.

