### PR TITLE
fix get app brightness hanging

### DIFF
--- a/android/src/main/java/com/ninty/system/setting/SystemSetting.java
+++ b/android/src/main/java/com/ninty/system/setting/SystemSetting.java
@@ -246,6 +246,7 @@ public class SystemSetting extends ReactContextBaseJavaModule implements Activit
     public void getAppBrightness(Promise promise) {
         final Activity curActivity = getCurrentActivity();
         if (curActivity == null) {
+            promise.reject("-1", "cannot get app brightness: current activity is null");
             return;
         }
         try {


### PR DESCRIPTION
The promise returned by `getAppBrightness` hangs when the current activity is not defined.