### PR TITLE
Added empty methods to silence NativeEventEmitter warnings

### DIFF
--- a/SystemSetting.js
+++ b/SystemSetting.js
@@ -4,6 +4,14 @@ import Utils from './Utils'
 
 const SystemSettingNative = NativeModules.SystemSetting
 
+SystemSettingNative.removeListeners = () => {
+    // This is a placeholder implementation
+}
+
+SystemSettingNative.addListener = () => {
+    // This is a placeholder implementation
+}
+
 const SCREEN_BRIGHTNESS_MODE_UNKNOW = -1
 const SCREEN_BRIGHTNESS_MODE_MANUAL = 0
 const SCREEN_BRIGHTNESS_MODE_AUTOMATIC = 1
@@ -207,12 +215,12 @@ export default class SystemSetting {
                 if (supported) await Linking.openURL(settingsLink);
                 break;
             }
-            case 'android': 
+            case 'android':
                 await SystemSettingNative.openAppSystemSettings()
                 break;
             default:
                 throw new Error('unknown platform')
-                break;    
+                break;
         }
     }
 


### PR DESCRIPTION
These empty methods will prevent the following warnings:

`new NativeEventEmitter() was called with a non-null argument without the required removeListeners method`